### PR TITLE
Update responses of Question 2 in Cluster-Administration section

### DIFF
--- a/Cluster-Administration/Questions1.md
+++ b/Cluster-Administration/Questions1.md
@@ -33,10 +33,10 @@ The other options are stored elsewhere:
 
 In a Kafka cluster, you have a topic with 6 partitions and a replication factor of 3. How many replicas of each partition will be spread across the brokers?
 
-- A. 1 replica per broker
-- B. 2 replicas per broker
-- C. 3 replicas per broker
-- D. 6 replicas per broker
+- A. 1 replica per partition
+- B. 2 replicas per partition
+- C. 3 replicas per partition
+- D. 6 replicas per partition
 
 <details>
 <summary>Response:</summary> 


### PR DESCRIPTION
The responses in the second question of the Cluster-Administration section are a little bit off. In the context, the question is asking about the number of replicas per partition and not per broker because we don't have any information about the brokers here and also it does not make sense to ask about it anyway.

Hence, I created this pull request so the readers are not confused in the future.